### PR TITLE
feat: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/aufgabe.yml
+++ b/.github/ISSUE_TEMPLATE/aufgabe.yml
@@ -1,0 +1,65 @@
+name: "Aufgabe"
+description: "Allgemeine Aufgabe (Refactoring, Chore, Infrastruktur)"
+title: "chore: "
+labels: ["chore"]
+body:
+  - type: dropdown
+    id: app
+    attributes:
+      label: "Betroffene App"
+      description: "Welche App ist betroffen?"
+      options:
+        - tsv-hub (Vereinsmanagement)
+        - tsv-auth (Benutzerverwaltung)
+        - tsv-dashboard (Zentrales Dashboard)
+        - tsv-helferhub (Base44 Helfer-App)
+        - tsv-website (TYPO3)
+        - tsv-docs (Dokumentation)
+        - Infrastruktur (Server, CI/CD, Docker)
+        - Uebergreifend (mehrere Apps)
+      default: 4
+    validations:
+      required: true
+
+  - type: dropdown
+    id: typ
+    attributes:
+      label: "Art der Aufgabe"
+      options:
+        - Refactoring
+        - Dependency-Update
+        - CI/CD
+        - Infrastruktur
+        - Dokumentation
+        - Sonstiges
+    validations:
+      required: true
+
+  - type: textarea
+    id: beschreibung
+    attributes:
+      label: "Beschreibung"
+      description: "Was soll gemacht werden und warum?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: "Definition of Done"
+      placeholder: |
+        - [ ] Aenderung implementiert
+        - [ ] Tests gruen
+        - [ ] Dokumentation aktualisiert
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Anweisungen fuer Claude Code
+
+        1. **Branch erstellen**: `git checkout -b chore/<kurzer-name>` von `develop`
+        2. **Aufgabe umsetzen**: Plan erstellen falls komplex, sonst direkt implementieren
+        3. **Verify**: Tests + Linting + Build
+        4. **Commit**: `chore: <beschreibung> (closes #ISSUE_NR)`
+        5. **PR erstellen**: `gh pr create --base develop`

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,79 @@
+name: "Bug Report"
+description: "Einen Fehler melden"
+title: "fix: "
+labels: ["fix"]
+body:
+  - type: dropdown
+    id: app
+    attributes:
+      label: "Betroffene App"
+      description: "In welcher App tritt der Fehler auf?"
+      options:
+        - tsv-hub (Vereinsmanagement)
+        - tsv-auth (Benutzerverwaltung)
+        - tsv-dashboard (Zentrales Dashboard)
+        - tsv-helferhub (Base44 Helfer-App)
+        - tsv-website (TYPO3)
+        - Uebergreifend (mehrere Apps)
+      default: 4
+    validations:
+      required: true
+
+  - type: textarea
+    id: beschreibung
+    attributes:
+      label: "Fehlerbeschreibung"
+      description: "Was passiert? Was sollte stattdessen passieren?"
+      placeholder: |
+        **Ist-Verhalten:** ...
+        **Soll-Verhalten:** ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduktion
+    attributes:
+      label: "Schritte zur Reproduktion"
+      description: "Wie kann der Fehler reproduziert werden?"
+      placeholder: |
+        1. Gehe zu ...
+        2. Klicke auf ...
+        3. Fehler tritt auf
+    validations:
+      required: true
+
+  - type: dropdown
+    id: schwere
+    attributes:
+      label: "Schweregrad"
+      options:
+        - Kritisch (App nicht nutzbar)
+        - Hoch (wichtige Funktion betroffen)
+        - Mittel (Workaround vorhanden)
+        - Niedrig (kosmetisch)
+    validations:
+      required: true
+
+  - type: textarea
+    id: kontext
+    attributes:
+      label: "Zusaetzlicher Kontext"
+      description: "Screenshots, Fehlermeldungen, Browser/OS, Logs."
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Anweisungen fuer Claude Code
+
+        Wenn du diesen Bug mit Claude Code behebst, folge diesem Ablauf:
+
+        1. **Repo auschecken**: `git checkout develop && git pull`
+        2. **Fix-Branch erstellen**: `git checkout -b fix/<kurzer-name>`
+        3. **Bug reproduzieren**: Verstehe das Problem — lies Logs, Tests, Code
+        4. **Ursache finden**: Systematic Debugging — nicht raten, sondern verifizieren
+        5. **Fix implementieren**: Minimaler Fix, kein Refactoring nebenbei
+        6. **Test schreiben**: Regressionstest der den Bug abdeckt
+        7. **Verify**: Alle Tests + Linting gruen
+        8. **Commit**: `fix: <beschreibung> (closes #ISSUE_NR)`
+        9. **PR erstellen**: `gh pr create --base develop`

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,66 @@
+name: "Feature Request"
+description: "Neues Feature vorschlagen oder implementieren"
+title: "feat: "
+labels: ["feat"]
+body:
+  - type: dropdown
+    id: app
+    attributes:
+      label: "Betroffene App"
+      description: "In welcher App soll das Feature implementiert werden?"
+      options:
+        - tsv-hub (Vereinsmanagement)
+        - tsv-auth (Benutzerverwaltung)
+        - tsv-dashboard (Zentrales Dashboard)
+        - tsv-helferhub (Base44 Helfer-App)
+        - tsv-website (TYPO3)
+        - tsv-docs (Dokumentation)
+        - Uebergreifend (mehrere Apps)
+      default: 4
+    validations:
+      required: true
+
+  - type: textarea
+    id: beschreibung
+    attributes:
+      label: "Beschreibung"
+      description: "Was soll implementiert werden? Beschreibe das gewuenschte Verhalten."
+      placeholder: "Als [Rolle] moechte ich [Funktion], damit [Nutzen]."
+    validations:
+      required: true
+
+  - type: textarea
+    id: akzeptanzkriterien
+    attributes:
+      label: "Akzeptanzkriterien"
+      description: "Wann ist das Feature fertig? Liste konkrete Kriterien."
+      placeholder: |
+        - [ ] Endpunkt GET /api/v1/... liefert Daten
+        - [ ] Frontend zeigt die Daten an
+        - [ ] Tests vorhanden und gruen
+        - [ ] Dokumentation aktualisiert
+    validations:
+      required: true
+
+  - type: textarea
+    id: kontext
+    attributes:
+      label: "Zusaetzlicher Kontext"
+      description: "Screenshots, Mockups, Links, oder technische Details."
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Anweisungen fuer Claude Code
+
+        Wenn du dieses Issue mit Claude Code bearbeitest, folge diesem Ablauf:
+
+        1. **Repo auschecken**: `git checkout develop && git pull`
+        2. **Feature-Branch erstellen**: `git checkout -b feature/<kurzer-name>`
+        3. **Plan erstellen**: Nutze Plan Mode — recherchiere die Codebase, erstelle einen Plan, klaere Rueckfragen
+        4. **Implementieren**: Arbeite die Akzeptanzkriterien Schritt fuer Schritt ab (TaskCreate pro Schritt)
+        5. **Verify**: Nach jedem Schritt Tests + Linting pruefen
+        6. **Dokumentation**: CLAUDE.md und/oder API-Spec aktualisieren falls noetig
+        7. **Commit**: Conventional Commit mit `closes #ISSUE_NR`
+        8. **PR erstellen**: `gh pr create --base develop` mit Verweis auf dieses Issue


### PR DESCRIPTION
## Summary
- Add feature, bug, and aufgabe issue templates with Claude Code instructions
- Templates have app pre-selection for tsv-website

## Test plan
- [ ] Verify templates appear when creating new issue on GitHub